### PR TITLE
Technical update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,24 +1,21 @@
-version: 2
-jobs:
-  build:
-    machine: true
-    steps:
-      - checkout
-      
-      - run:
-          name: Install architect
-          command: |
-            wget -q $(curl -sS -H "Authorization: token $RELEASE_TOKEN" https://api.github.com/repos/giantswarm/architect/releases/tags/v1.0.0 | grep browser_download_url | head -n 1 | cut -d '"' -f 4)
-            chmod +x ./architect
-            ./architect version
-      
-      - run:
-          name: architect build
-          command: ./architect build
-      
-      - deploy:
-          name: architect deploy (master only)
-          command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              ./architect deploy
-            fi
+version: 2.1
+orbs:
+  architect: giantswarm/architect@2.8.0
+
+workflows:
+  my-workflow:
+    jobs:
+
+      - architect/push-to-docker:
+          context: "architect"
+          name: "push-signcode-util-to-quay"
+          image: "quay.io/giantswarm/signcode-util"
+          username_envar: "QUAY_USERNAME"
+          password_envar: "QUAY_PASSWORD"
+          build-context: "."
+          dockerfile: "./Dockerfile"
+          tag-suffix: ""
+          filters:
+            # Trigger job also on git tag.
+            tags:
+              only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ orbs:
   architect: giantswarm/architect@2.8.0
 
 workflows:
-  my-workflow:
+  build-workflow:
     jobs:
 
       - architect/push-to-docker:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Use upstream source [mtrojnar/osslsigncode](https://github.com/mtrojnar/osslsigncode) instead of the old SourceForge project, which no longer exists.
+- Update CI configuration and use architect-orb.
+- Improve Dockerfile for smaller resulting image and a simpler build.
+
+[Unreleased]: https://github.com/giantswarm/REPOSITORY_NAME/tree/master

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 
 # signcode-util
 
-A Docker container for [osslsigncode](https://sourceforge.net/projects/osslsigncode/files/osslsigncode/) to sign binaries for Windows.
-
+A Docker image for [osslsigncode](https://github.com/mtrojnar/osslsigncode) to sign binaries for Windows.
 
 ## Usage
 
@@ -44,7 +43,7 @@ docker run --rm -ti \
 
 The output will look similar to this:
 
-```
+```nohighlight
 Current PE checksum   : 00AC0656
 Calculated PE checksum: 00AC0656
 
@@ -55,20 +54,20 @@ Calculated message digest : 05830C452810052993D51FBDC180FFCD3BA920DA
 Signature verification: ok
 
 Number of signers: 1
-	Signer #0:
-		Subject: /C=DE/postalCode=50670/ST=Nordrhein-Westfalen/L=Cologne/street=c/o Startplatz/street=Im Mediapark 5/O=Giant Swarm GmbH/CN=Giant Swarm GmbH
-		Issuer : /C=US/O=SSL.com/OU=www.ssl.com/CN=SSL.com Object CA
+  Signer #0:
+    Subject: /C=DE/postalCode=50670/ST=Nordrhein-Westfalen/L=Cologne/street=c/o Startplatz/street=Im Mediapark 5/O=Giant Swarm GmbH/CN=Giant Swarm GmbH
+    Issuer : /C=US/O=SSL.com/OU=www.ssl.com/CN=SSL.com Object CA
 
 Number of certificates: 3
-	Cert #0:
-		Subject: /C=DE/postalCode=50670/ST=Nordrhein-Westfalen/L=Cologne/street=c/o Startplatz/street=Im Mediapark 5/O=Giant Swarm GmbH/CN=Giant Swarm GmbH
-		Issuer : /C=US/O=SSL.com/OU=www.ssl.com/CN=SSL.com Object CA
-	Cert #1:
-		Subject: /C=US/O=SSL.com/OU=www.ssl.com/CN=SSL.com Object CA
-		Issuer : /C=US/ST=New Jersey/L=Jersey City/O=The USERTRUST Network/CN=USERTrust RSA Certification Authority
-	Cert #2:
-		Subject: /C=US/ST=New Jersey/L=Jersey City/O=The USERTRUST Network/CN=USERTrust RSA Certification Authority
-		Issuer : /C=US/ST=New Jersey/L=Jersey City/O=The USERTRUST Network/CN=USERTrust RSA Certification Authority
+  Cert #0:
+    Subject: /C=DE/postalCode=50670/ST=Nordrhein-Westfalen/L=Cologne/street=c/o Startplatz/street=Im Mediapark 5/O=Giant Swarm GmbH/CN=Giant Swarm GmbH
+    Issuer : /C=US/O=SSL.com/OU=www.ssl.com/CN=SSL.com Object CA
+  Cert #1:
+    Subject: /C=US/O=SSL.com/OU=www.ssl.com/CN=SSL.com Object CA
+    Issuer : /C=US/ST=New Jersey/L=Jersey City/O=The USERTRUST Network/CN=USERTrust RSA Certification Authority
+  Cert #2:
+    Subject: /C=US/ST=New Jersey/L=Jersey City/O=The USERTRUST Network/CN=USERTrust RSA Certification Authority
+    Issuer : /C=US/ST=New Jersey/L=Jersey City/O=The USERTRUST Network/CN=USERTrust RSA Certification Authority
 
 Succeeded
 ```


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/17271

This PR includes several changes:

- Now uses upstream source [mtrojnar/osslsigncode](https://github.com/mtrojnar/osslsigncode), as the old project on SourceForge no longer exists.
- Dockerfile changed to a multi-stage build, for a smaller image and a simpler build
- Use architect-orb
- Add CHANGELOG
